### PR TITLE
Adds better auth method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # Project data
 data/
+
+# TwitterAPI credentials
+bearer_token

--- a/TwitterAPI.py
+++ b/TwitterAPI.py
@@ -35,7 +35,7 @@ class TwitterAPI(LoggingHandler):
         # To set your enviornment variables in your terminal run the following line:
         # export 'BEARER_TOKEN'='<your_bearer_token>'
         # self.BEARER_TOKEN = os.environ.get("BEARER_TOKEN")
-        self.BEARER_TOKEN = ""
+        self.BEARER_TOKEN = open('bearer_token').read()
         self.BASE_URL = "https://api.twitter.com/2"
 
     def get_bearer_header(self):


### PR DESCRIPTION
Introduces external (to script) user credential storage for TwitterAPI.py. Also modifies .gitignore to ignore credential file. To use, simply save Twitter bearer token string in file called 'bearer_token' at root level in project repo.